### PR TITLE
Added import to Typekit in css for Garamond font

### DIFF
--- a/Group 1/CTSDWebsite/src/main/webapp/softwareDev.css
+++ b/Group 1/CTSDWebsite/src/main/webapp/softwareDev.css
@@ -1,3 +1,5 @@
+@import "https://use.typekit.net/cmk3ebk.css";
+
 body {
   margin: 20px;
 }
@@ -48,7 +50,7 @@ html, body {
 body {
     background-color: white;
     color: black;
-    font-family: Arial, sans-serif;
+    font-family: "adobe-garamond-pro", serif;
     font-size: 1.5em;
     line-height: 1.5; 
   }
@@ -56,7 +58,7 @@ body {
 /* Headings styles */
 h2, h3, h4, h5, h6 {
 background-color: rgba(220, 221, 222, 1);
-font-family: Arial, sans-serif;
+font-family: "adobe-garamond-pro", serif;
 font-size: 1.5em;
 line-height: 1.2;
 color: black;
@@ -65,7 +67,7 @@ text-indent: 20px;
   
 h1{
 text-align: center;
-font-family: Ariel, sans-serif;
+font-family: "adobe-garamond-pro", serif;
 font-size: 2em;
 line-height: 1.2;
 }


### PR DESCRIPTION
Imported the Typekit css into the SoftwareDev css and replaced calls to Ariel with calls to Garamond Pro.