### PR TITLE
Hide concentration summary if screen is not large

### DIFF
--- a/Main Page/main_page.html
+++ b/Main Page/main_page.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Computing Technology and Software Design</title>
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <link
@@ -58,7 +59,7 @@
     </header>
 
     <main class="container">
-      <section class="summary">
+      <div class="summary">
         <h1 class="BAS">
           Bachelor of Science in Computing Technology and Software Design
         </h1>
@@ -107,8 +108,8 @@
             </ul>
           </div>
         </div>
-      </section>
-      <section class="row paths">
+      </div>
+      <div class="row paths">
         <div class="col position-relative">
           <div
             class="overlay position-absolute top-50 start-50 translate-middle"
@@ -120,7 +121,7 @@
                 >Software Development
               </a>
             </h3>
-            <p>
+            <p class="d-none d-lg-block">
               The Software Development concentration utilizes project-based
               coursework to demonstrate industry-standard practices including
               popular programming languages/frameworks, using restful APIs for
@@ -152,7 +153,7 @@
                 >Cloud Computing</a
               >
             </h3>
-            <p>
+            <p class="d-none d-lg-block">
               The Cloud Computing concentration teaches students the
               fundamentals of architecting, development, and administration for
               popular cloud computing platforms. Students will gain hands-on
@@ -177,7 +178,7 @@
           <!--This video came from:
         Video by Pressmaster: https://www.pexels.com/video/digital-calculation-in-geometrical-symmetry-3141210/ -->
         </div>
-      </section>
+      </div>
 
       <section>
         <div class="row">


### PR DESCRIPTION
Both concentration summary texts will now hide if the screen size shrinks past bootstraps "large" classification (992 px). Resolves issue #14 

![image](https://github.com/FriendlyCharles/CTSD-Web-Project/assets/44072978/6f317dec-c86e-4ecc-b736-1b0ae37b9eb6)
